### PR TITLE
Force version of ruby to less than 2.2

### DIFF
--- a/onlyoffice_pdf_parser.gemspec
+++ b/onlyoffice_pdf_parser.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name = 'onlyoffice_pdf_parser'
   s.version = OnlyofficePdfParser::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 1.9'
+  s.required_ruby_version = ['>= 2.0', '< 2.2']
   s.authors = ['Pavel Lobashov', 'Dmitry Rotaty']
   s.summary = 'ONLYOFFICE Testrail Wrapper Gem'
   s.description = 'Wrapper for Testrail by OnlyOffice'


### PR DESCRIPTION
Since this bug is not resolved
https://bugs.ruby-lang.org/issues/12670
It will not work on ruby newer that 2.1 with segfault error.