### PR TITLE
`fetch_bmp_stream` return value shouldn't be checked

### DIFF
--- a/spec/pdf_parser_spec.rb
+++ b/spec/pdf_parser_spec.rb
@@ -48,14 +48,14 @@ describe 'Check PDF parser' do
 
   it 'convert pdf to bmp' do
     pdf_info = OnlyofficePdfParser::PdfParser.parse('spec/pdf_examples/empty_font_name.pdf')
-    bmp = pdf_info.fetch_bmp_stream
-    expect(File.size(bmp)).to be > 1000
+    pdf_info.fetch_bmp_stream
+    expect(pdf_info.bmp_stream.length).to be > 1000
   end
 
   it 'convert pdf to bmp file with space' do
     pdf_info = OnlyofficePdfParser::PdfParser.parse('spec/pdf_examples/space in font name.pdf')
-    bmp = pdf_info.fetch_bmp_stream
-    expect(File.size(bmp)).to be > 1000
+    pdf_info.fetch_bmp_stream
+    expect(pdf_info.bmp_stream.length).to be > 1000
   end
 
   it 'check pdf for pattern' do


### PR DESCRIPTION
It return result of `Tempfile#unlink` and
return value of this method changed in ruby 2.3
See:
https://github.com/ruby/ruby/commit/354c9747e49ae1c68fa4be696da36cc51c40713c
It return `true` since, not file itself.
So check file size could be broken on newest rubies.