### PR TITLE
Use binary mode to write file for fetch pixels

### DIFF
--- a/lib/onlyoffice_pdf_parser/bmp_image.rb
+++ b/lib/onlyoffice_pdf_parser/bmp_image.rb
@@ -96,7 +96,7 @@ module OnlyofficePdfParser
     # @return [Void] Fill @pixel with data
     def fetch_pixels
       tmp_file = Tempfile.new('onlyoffice_pdf_parser')
-      File.open(tmp_file, 'w') { |file| file.write(data) }
+      File.open(tmp_file, 'wb') { |file| file.write(data) }
       @pixels = ImageList.new(tmp_file.path).get_pixels(0, 0, width, height).each_slice(width).to_a
       tmp_file.unlink
     end


### PR DESCRIPTION
Without this it cause
`Encoding::UndefinedConversionError: "\x82" from ASCII-8BIT to UTF-8`
in some cases, but can't reproduce with simple test