### PR TITLE
Fix policy for converting pdf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   - rvm: 2.2.10
 bundler_args: "--without development"
 script:
-  - sed -i '/PDF/d' /etc/ImageMagick-6/policy.xml
+  - sudo sed -i '/PDF/d' /etc/ImageMagick-6/policy.xml
   - bundle exec rspec
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ matrix:
   - rvm: 2.2.10
 bundler_args: "--without development"
 script:
-- bundle exec rspec
+  - sed -i '/PDF/d' /etc/ImageMagick-6/policy.xml
+  - bundle exec rspec
 addons:
   apt:
     packages:


### PR DESCRIPTION
After some upgrade of ImageMagick policy is forbidden to
convert PDF to BMP. Remove this config line.