### PR TITLE
Remove ability to compare `CursorPoint` and `Coordinates`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,3 +16,4 @@
 ### Removal
 
 * Remove unused `BmpImage#get_sub_image_center_array`
+* Remove ability to compare `CursorPoint` and `Coordinates`

--- a/lib/onlyoffice_pdf_parser/helpers/cursor_point.rb
+++ b/lib/onlyoffice_pdf_parser/helpers/cursor_point.rb
@@ -26,8 +26,6 @@ module OnlyofficePdfParser
     def ==(other)
       if other.respond_to?(:left) && other.respond_to?(:top)
         @left == other.left && @top == other.top
-      elsif other.is_a? Coordinates
-        @left == other.row && @top == other.column
       else
         false
       end


### PR DESCRIPTION
Seems this is some leftover code from older times